### PR TITLE
Disable to unload last scene

### DIFF
--- a/Runtime/Assets/Scene/UnifiedSceneLoader.cs
+++ b/Runtime/Assets/Scene/UnifiedSceneLoader.cs
@@ -93,8 +93,17 @@ namespace Mew.Core.Assets
 #endif
                 case SceneHandle sceneHandle:
                 {
+                    if (SceneManager.loadedSceneCount <= 1)
+                    {
+                        Debug.Log("There is only one scene loaded. Cannot unload.");
+                        break;
+                    }
+
                     if (sceneHandle.Scene.isLoaded)
+                    {
                         await CompatibleSceneLoader.UnloadSceneAsync(sceneHandle);
+                    }
+
                     break;
                 }
             }

--- a/Runtime/Helpers/Compatibility/TaskHelperInternal.cs
+++ b/Runtime/Helpers/Compatibility/TaskHelperInternal.cs
@@ -31,7 +31,7 @@ namespace Mew.Core.TaskHelpers
             ct.ThrowIfCancellationRequested();
             return;
 
-            void OnUpdate()
+            static void OnUpdate()
             {
                 while (Queued.Count > 0)
                     Running.Add(Queued.Dequeue());

--- a/Runtime/Helpers/SceneManagerHelper.cs
+++ b/Runtime/Helpers/SceneManagerHelper.cs
@@ -1,7 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using UnityEngine;
 using UnityEngine.SceneManagement;
 
 namespace Mew.Core.SceneHelpers


### PR DESCRIPTION
When stop editor player using Doinject, "Reverse loaded context scene" try to unload last scene.