### PR TITLE
Fix compile error on unity 2022

### DIFF
--- a/Runtime/Assets/Scene/SceneHandle.cs
+++ b/Runtime/Assets/Scene/SceneHandle.cs
@@ -46,7 +46,7 @@ namespace Mew.Core.Assets
 
             if (ct.IsCancellationRequested)
             {
-                await SceneManager.UnloadSceneAsync(Scene);
+                await UnifiedSceneLoader.UnloadAsync(this);
                 ct.ThrowIfCancellationRequested();
             }
             return Scene;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "st.mewli.core",
   "displayName": "MewCore",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "unity": "2022.3",
   "description": "Core Game Library for Unity",
   "author": {


### PR DESCRIPTION
#37

On Unity2022 ```SceneManager.UnloadSceneAsync``` does not have GetAwaiter.
Replace it to version compatible api ```UnifiedSceneLoader.UnloadAsync```.